### PR TITLE
Set up

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'/>
+  <title>Rainbow Connection Products</title>
+  <link rel='stylesheet' href='main.css'/>
+</head>
+<body>
+  <h1>Rainbow Connection Products!</h1>
+  <div class='container'>
+    <div class='card'>
+      <header class="card-title">
+        <h2>Rainbow Unicorn</h2>
+      </header>
+      <section class='basics'>
+        <img class="image" src='?' alt='A picture of a beautiful unicorn'/>
+        <p class='product-description'>Have you ever wondered if unicorns and you were really a good fit? Wonder no more! Our Rainbow Unicorn will be your best friend in no time!</p>
+        <p class='availability'>Available!</p>
+      </section>
+      <section class='specifications'>
+        <header>
+          <h4>Specifications</h4>
+        </header>
+        <div class='size'>
+          <p>Perfect for you!</p>
+        </div>
+        <div class='weight'>
+          <p>Light as a feather</p>
+        </div>
+        <footer>
+          <p>When the unicorn is sad, they get bent out of shape.</p>
+        </footer>
+      </section>
+      <section class="price">
+        <header>
+          <h4>Pricing</h4>
+        </header>
+        <div>
+          <p>3 wishes per single glimpse</p>
+        </div>
+        <div>
+          <p>A feeling of joy for the chance to meet them</p>
+        </div>
+        <div>
+          <p>Loyalty and mutual care for the possibility of friendship</p>
+        </div>
+      </section>
+    </div>
+    <div class='card'>
+      <header class="card-title">
+        <h2>Rainbow Rainbow</h2>
+      </header>
+      <section class='basics'>
+        <img class="image" src='?' alt='Picture of a gorgeous rainbow!'/>
+        <p class='product-description'>Our Rainbow Rainbow is the rainbowiest of all rainbows, and you defs need it in your life!</p>
+        <p class='availability'>Supes Available!</p>
+      </section>
+      <section class='specifications'>
+        <header>
+          <h4>Specifications</h4>
+        </header>
+        <div class='size'>
+          <p>Sky-wide</p>
+        </div>
+        <div class='weight'>
+          <p>Weightless</p>
+        </div>
+        <footer>
+          <p>When obscured by clouds, may not meet specifications.</p>
+        </footer>
+      </section>
+      <section class="price">
+        <header>
+          <h4>Pricing</h4>
+        </header>
+        <div>
+          <p>Sunshine on a rainy day for a sighting</p>
+        </div>
+        <div>
+          <p>A parting of the clouds for a gorgeous glory</p>
+        </div>
+        <div>
+          <p>A keen eye and a wistful heart to find the rainbow's end</p>
+        </div>
+      </section>
+    </div>
+    <div class='card'>
+      <header class="card-title">
+        <h2>Rainbow Prism</h2>
+      </header>
+      <section class='basics'>
+        <img class="image" src='?' alt='prism'/>
+        <p class='product-description'>Every fractured moment in life is reflected in a gentler hue by our Rainbow Prism. Dance with the moments and the tiny glories of color and you'll...maybe not be all better, but hopefully not worse? Anyway it's a very nice prism.</p>
+        <p class='availability'>Very available!</p>
+      </section>
+      <section class='specifications'>
+        <header>
+          <h4>Specifications</h4>
+        </header>
+        <div class='size'>
+          <p>About the size of Thumbelina's bed.</p>
+        </div>
+        <div class='weight'>
+          <p>More than you'd expect.</p>
+        </div>
+        <footer>
+          <p>When you are a good guesser, may not meet weight specifications.</p>
+        </footer>
+      </section>
+      <section class="price">
+        <header>
+          <h4>Pricing</h4>
+        </header>
+        <div>
+          <p>A twinkle for a shimmer</p>
+        </div>
+        <div>
+          <p>A ray of sunshine for a sparkle</p>
+        </div>
+        <div>
+          <p>A world of light for a dazzle</p>
+        </div>
+      </section>
+    </div>
+    <div class='card'>
+      <header class="card-title">
+        <h2>Rainbow Reflection</h2>
+      </header>
+      <section class='basics'>
+        <img class="image" src='?' alt='reflection'/>
+        <p class='product-description'>If our Rainbow Rainbow wasn't rainbowy enough for you, here's a reflection of a rainbow! If the prism doesn't work, we recommend getting this product, because it's sweet as all get out!</p>
+        <p class='availability'>Delightfully available!</p>
+      </section>
+      <section class='specifications'>
+        <header>
+          <h4>Specifications</h4>
+        </header>
+        <div class='size'>
+          <p>Pond-wide</p>
+        </div>
+        <div class='weight'>
+          <p>Weightless</p>
+        </div>
+        <footer>
+          <p>May not meet specifications depending on reflective surface.</p>
+        </footer>
+      </section>
+      <section class="price">
+        <header>
+          <h4>Pricing</h4>
+        </header>
+        <div>
+          <p>A still, cool surface for a quiet hue</p>
+        </div>
+        <div>
+          <p>A still, clear pond for the full effect</p>
+        </div>
+        <div>
+          <p>A larger body of water, also still and clear, for a magical experience</p>
+        </div>
+      </section>
+    </div>
+    <div class='card'>
+      <header class="card-title">
+        <h2>Rainbow World</h2>
+      </header>
+      <section class='basics'>
+        <img class="image" src='?' alt='world'/>
+        <p class='product-description'>Our dream is for every shade to be represented throughout all space and time. Our Rainbow World is a tiny glimpse of that vision.</p>
+        <p class='availability'>Coming soon!</p>
+      </section>
+      <section class='specifications'>
+        <header>
+          <h4>Specifications</h4>
+        </header>
+        <div class='size'>
+          <p>Not as big as I'd like it to be</p>
+        </div>
+        <div class='weight'>
+          <p>Not as hard to hold as Atlas keeps making it out to be</p>
+        </div>
+        <footer>
+          <p>Does not meet specifications consistently, because Atlas might be right sometimes.</p>
+        </footer>
+      </section>
+      <section class="price">
+        <header>
+          <h4>Pricing</h4>
+        </header>
+        <div>
+          <p>A world of pain to heal, for just the beginning</p>
+        </div>
+        <div>
+          <p>All the cycles and curses to break, to be set free</p>
+        </div>
+        <div>
+          <p>And then, maybe, for every tear that's cried, maybe we'll find hope again</p>
+        </div>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/main.css
+++ b/main.css
@@ -1,0 +1,12 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+    body {
+display: flexbox;
+flex-flow: row wrap;
+}
+.card {
+width: 30%;
+}


### PR DESCRIPTION

Run in browser to display page with five products cards under a level 1 heading announcing the name of the company. Each product has a level 2 heading with its name and 2 level 2 headings that announcs the "specifications" and "pricing" sections. An graphic with no image appears with each product along with miscelaneous text lines under each section heading. 
The default styling for the page has been removed, and the cards should display with three on a row, three on the first row and two on the second.
